### PR TITLE
Focus on Pivot Indicators

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    quantitative (0.3.2)
+    quantitative (0.3.3)
       oj (~> 3.10)
       zeitwerk (~> 2.6)
 

--- a/lib/quant/indicators/indicator.rb
+++ b/lib/quant/indicators/indicator.rb
@@ -98,9 +98,18 @@ module Quant
         series.indicators[source][dominant_cycle_indicator_class]
       end
 
-      def dc_period
+      # The adaptive period is the full dominant cycle period
+      def adaptive_period
         dominant_cycle.points[t0].period
       end
+      alias dc_period adaptive_period
+      alias dominant_cycle_period adaptive_period
+
+      def adaptive_half_period
+        adaptive_period / 2
+      end
+      alias dc_half_period adaptive_half_period
+      alias dominant_half_cycle_period adaptive_half_period
 
       def ticks
         @points.keys
@@ -193,66 +202,13 @@ module Quant
         t0.send(source)
       end
 
-      # def warmed_up?
-      #   true
-      # end
-
-      # attr_reader :dc_period
-
-      # def points_for(series:)
-      #   @points_for_cache[series] ||= self.class.new(series:, settings:, cloning: true).tap do |indicator|
-      #     series.ticks.each { |tick| indicator.points.push(tick.indicators[self]) }
-      #   end
-      # end
-
-      # # Ticks belong to the first series they're associated with always
-      # # NOTE: No provisions for series merging their ticks to one series!
-      # def parent_series
-      #   series.ticks.empty? ? series : series.ticks.first.series
-      # end
-
-      # # Returns the last point of the current indicator rather than the entire series
-      # # This is used for indicators that depend on dominant cycle or other indicators
-      # # to compute their data points.
-      # def current_point
-      #   points.size - 1
-      # end
-
-      # def dominant_cycles
-      #   parent_series.indicators.dominant_cycles
-      # end
-
-      # # Override this method to change source of dominant cycle computation for an indicator
-      # def dominant_cycle_indicator
-      #   @dominant_cycle_indicator ||= dominant_cycles.band_pass
-      # end
-
-      # def ensure_not_dominant_cycler_indicator
-      #   return unless is_a? Quant::Indicators::DominantCycles::DominantCycle
-
-      #   raise 'Dominant Cycle Indicators cannot use the thing they compute!'
-      # end
-
-      # # Returns the dominant cycle point for the current indicator's point
-      # def current_dominant_cycle
-      #   dominant_cycle_indicator[current_point]
-      # end
+      def warmed_up?
+        ticks.size > min_period
+      end
 
       # # Returns the atr point for the current indicator's point
       # def atr_point
       #   parent_series.indicators.atr[current_point]
-      # end
-
-      # # def dc_period
-      # #   dominant_cycle.period.round(0).to_i
-      # # end
-
-      # def <<(ohlc)
-      #   points.append(ohlc)
-      # end
-
-      # def append(ohlc)
-      #   points.append(ohlc)
       # end
     end
   end

--- a/lib/quant/indicators/indicator_point.rb
+++ b/lib/quant/indicators/indicator_point.rb
@@ -32,6 +32,7 @@ module Quant
       def_delegator :tick, :close_price
       def_delegator :tick, :open_price
       def_delegator :tick, :volume
+      def_delegator :tick, :trades
 
       def oc2
         tick.respond_to?(:oc2) ? tick.oc2 : tick.close_price

--- a/lib/quant/indicators/indicator_point.rb
+++ b/lib/quant/indicators/indicator_point.rb
@@ -27,6 +27,16 @@ module Quant
       def_delegator :indicator, :dominant_cycle_kind
       def_delegator :indicator, :pivot_kind
 
+      def_delegator :tick, :high_price
+      def_delegator :tick, :low_price
+      def_delegator :tick, :close_price
+      def_delegator :tick, :open_price
+      def_delegator :tick, :volume
+
+      def oc2
+        tick.respond_to?(:oc2) ? tick.oc2 : tick.close_price
+      end
+
       def initialize_data_points
         # No-Op - Override in subclass if needed.
       end

--- a/lib/quant/indicators/pivots/atr.rb
+++ b/lib/quant/indicators/pivots/atr.rb
@@ -10,31 +10,25 @@ module Quant
         end
 
         def scale
-          5.0
+          3.0
         end
 
         def atr_value
-          atr_point.slow * scale
+          atr_point.value * scale
         end
 
         def compute_midpoint
-          p0.midpoint = two_pole_super_smooth :input, previous: :midpoint, period: averaging_period
+          p0.midpoint = smoothed_average_midpoint
         end
 
-        def compute_bands
-          p0.h6 = p0.midpoint + 1.000 * atr_value
-          p0.h5 = p0.midpoint + 0.786 * atr_value
-          p0.h4 = p0.midpoint + 0.618 * atr_value
-          p0.h3 = p0.midpoint + 0.500 * atr_value
-          p0.h2 = p0.midpoint + 0.382 * atr_value
-          p0.h1 = p0.midpoint + 0.236 * atr_value
+        ATR_SERIES = [0.236, 0.382, 0.500, 0.618, 0.786, 1.0].freeze
 
-          p0.l1 = p0.midpoint - 0.236 * atr_value
-          p0.l2 = p0.midpoint - 0.382 * atr_value
-          p0.l3 = p0.midpoint - 0.500 * atr_value
-          p0.l4 = p0.midpoint - 0.618 * atr_value
-          p0.l5 = p0.midpoint - 0.786 * atr_value
-          p0.l6 = p0.midpoint - 1.000 * atr_value
+        def compute_bands
+          ATR_SERIES.each_with_index do |ratio, index|
+            offset = ratio * atr_value
+            p0[index + 1] = p0.midpoint + offset
+            p0[-index - 1] = p0.midpoint - offset
+          end
         end
       end
     end

--- a/lib/quant/indicators/pivots/bollinger.rb
+++ b/lib/quant/indicators/pivots/bollinger.rb
@@ -9,37 +9,20 @@ module Quant
         using Quant
 
         def compute_midpoint
-          values = period_points(half_period).map(&:input)
-          alpha = bars_to_alpha(half_period)
+          values = period_points(adaptive_half_period).map(&:input)
+          alpha = bars_to_alpha(adaptive_half_period)
 
           p0.midpoint = alpha * values.mean + (1 - alpha) * p1.midpoint
           p0.std_dev = values.standard_deviation(p0.midpoint)
         end
 
+        BOLLINGER_SERIES = [1.0, 1.5, 1.75, 2.0, 2.25, 2.5, 2.75, 3.0].freeze
+
         def compute_bands
-          p0.h1 = p0.midpoint + p0.std_dev * 1.0
-          p0.l1 = p0.midpoint - p0.std_dev * 1.0
-
-          p0.h2 = p0.midpoint + p0.std_dev * 1.5
-          p0.l2 = p0.midpoint - p0.std_dev * 1.5
-
-          p0.h3 = p0.midpoint + p0.std_dev * 1.75
-          p0.l3 = p0.midpoint - p0.std_dev * 1.75
-
-          p0.h4 = p0.midpoint + p0.std_dev * 2.0
-          p0.l4 = p0.midpoint - p0.std_dev * 2.0
-
-          p0.h5 = p0.midpoint + p0.std_dev * 2.25
-          p0.l5 = p0.midpoint - p0.std_dev * 2.25
-
-          p0.h6 = p0.midpoint + p0.std_dev * 2.5
-          p0.l6 = p0.midpoint - p0.std_dev * 2.5
-
-          p0.h7 = p0.midpoint + p0.std_dev * 2.75
-          p0.l7 = p0.midpoint - p0.std_dev * 2.75
-
-          p0.h8 = p0.midpoint + p0.std_dev * 3.0
-          p0.l8 = p0.midpoint - p0.std_dev * 3.0
+          BOLLINGER_SERIES.each_with_index do |ratio, index|
+            p0[index + 1] = p0.midpoint + ratio * p0.std_dev
+            p0[-index - 1] = p0.midpoint - ratio * p0.std_dev
+          end
         end
       end
     end

--- a/lib/quant/indicators/pivots/camarilla.rb
+++ b/lib/quant/indicators/pivots/camarilla.rb
@@ -7,51 +7,52 @@ module Quant
       # input the previous day’s open, high, low and close. The formulas for each
       # resistance and support level are:
       #
-      # R4 = Close + (High – Low) * 1.1/2
-      # R3 = Close + (High – Low) * 1.1/4
-      # R2 = Close + (High – Low) * 1.1/6
-      # R1 = Close + (High – Low) * 1.1/12
-      # S1 = Close – (High – Low) * 1.1/12
-      # S2 = Close – (High – Low) * 1.1/6
-      # S3 = Close – (High – Low) * 1.1/4
-      # S4 = Close – (High – Low) * 1.1/2
+      # R4 = Closing + ((High -Low) x 1.5000)
+      # R3 = Closing + ((High -Low) x 1.2500)
+      # R2 = Closing + ((High -Low) x 1.1666)
+      # R1 = Closing + ((High -Low x 1.0833)
+      # PP = (High + Low + Closing) / 3
+      # S1 = Closing – ((High -Low) x 1.0833)
+      # S2 = Closing – ((High -Low) x 1.1666)
+      # S3 = Closing – ((High -Low) x 1.2500)
+      # S4 = Closing – ((High-Low) x 1.5000)
+      #
+      # R5 = R4 + 1.168 * (R4 – R3)
+      # R6 = (High/Low) * Close
+      # S5 = S4 – 1.168 * (S3 – S4)
+      # S6 = Close – (R6 – Close)
       #
       # The calculation for further resistance and support levels varies from this
       # norm. These levels can come into play during strong trend moves, so it’s
       # important to understand how to identify them. For example, R5, R6, S5 and S6
       # are calculated as follows:
       #
-      # R5 = R4 + 1.168 * (R4 – R3)
-      # R6 = (High/Low) * Close
-      #
-      # S5 = S4 – 1.168 * (S3 – S4)
-      # S6 = Close – (R6 – Close)
+      # source: https://tradingstrategyguides.com/camarilla-pivot-trading-strategy/
       class Camarilla < Pivot
         register name: :camarilla
 
         def compute_midpoint
-          p0.midpoint = t0.close_price
+          p0.midpoint = t0.hlc3
         end
 
         def compute_bands
-          mp_plus_range = p0.midpoint + p0.range
-          mp_minus_range = p0.midpoint - p0.range
+          p0.h1 = t0.close_price + p0.range * 1.083
+          p0.l1 = t0.close_price - p0.range * 1.083
 
-          p0.h4 = mp_plus_range * (1.1 / 2.0)
-          p0.h3 = mp_plus_range * (1.1 / 4.0)
-          p0.h2 = mp_plus_range * (1.1 / 6.0)
-          p0.h1 = mp_plus_range * (1.1 / 12.0)
+          p0.h2 = t0.close_price + p0.range * 1.167
+          p0.l2 = t0.close_price - p0.range * 1.167
 
-          p0.l1 = mp_minus_range * (1.1 / 12.0)
-          p0.l2 = mp_minus_range * (1.1 / 6.0)
-          p0.l3 = mp_minus_range * (1.1 / 4.0)
-          p0.l4 = mp_minus_range * (1.1 / 2.0)
+          p0.h3 = t0.close_price + p0.range * 1.250
+          p0.l3 = t0.close_price - p0.range * 1.250
 
-          p0.h5 = p0.h4 + 1.168 * (p0.h4 - p0.h3)
-          p0.h6 = p0.midpoint * (p0.high_price / p0.low_price)
+          p0.h4 = t0.close_price + p0.range * 1.500
+          p0.l4 = t0.close_price - p0.range * 1.500
 
-          p0.l5 = p0.l4 - 1.168 * (p0.l3 - p0.l4)
-          p0.l6 = p0.midpoint - (p0.h6 - p0.midpoint)
+          p0.h5 = p0.h4 + 1.68 * (p0.h4 - p0.h3)
+          p0.l5 = p0.l4 - 1.68 * (p0.l3 - p0.l4)
+
+          p0.h6 = (t0.high_price / t0.low_price) * t0.close_price
+          p0.l6 = t0.close_price - (p0.h6 - t0.close_price)
         end
       end
     end

--- a/lib/quant/indicators/pivots/classic.rb
+++ b/lib/quant/indicators/pivots/classic.rb
@@ -7,7 +7,7 @@ module Quant
         register name: :classic
 
         def compute_midpoint
-          p0.midpoint = super_smoother :input, previous: :midpoint, period: averaging_period
+          p0.midpoint = smoothed_average_midpoint
         end
 
         def compute_bands

--- a/lib/quant/indicators/pivots/demark.rb
+++ b/lib/quant/indicators/pivots/demark.rb
@@ -36,15 +36,15 @@ module Quant
 
         def compute_midpoint
           p0.midpoint = p0.input / 4.0
-          p0.midpoint = super_smoother :midpoint, previous: :midpoint, period: averaging_period
+          p0.midpoint = three_pole_super_smooth :midpoint, previous: :midpoint, period: averaging_period
         end
 
         def compute_bands
           p0.h1 = (p0.input / 2.0) - p0.avg_high
-          p0.h1 = super_smoother :h1, previous: :h1, period: averaging_period
+          p0.h1 = three_pole_super_smooth :h1, previous: :h1, period: averaging_period
 
           p0.l1 = (p0.input / 2.0) - p0.avg_low
-          p0.l1 = super_smoother :l1, previous: :l1, period: averaging_period
+          p0.l1 = three_pole_super_smooth :l1, previous: :l1, period: averaging_period
         end
       end
     end

--- a/lib/quant/indicators/pivots/donchian.rb
+++ b/lib/quant/indicators/pivots/donchian.rb
@@ -5,35 +5,31 @@ module Quant
     module Pivots
       class Donchian < Pivot
         register name: :donchian
-        using Quant
 
-        def st_period; min_period end
-        def mt_period; half_period end
-        def lt_period; max_period end
-
-        def st_highs; @st_highs ||= [].max_size!(st_period) end
-        def st_lows; @st_lows ||= [].max_size!(st_period) end
-        def mt_highs; @mt_highs ||= [].max_size!(mt_period) end
-        def mt_lows; @mt_lows ||= [].max_size!(mt_period) end
-        def lt_highs; @lt_highs ||= [].max_size!(lt_period) end
-        def lt_lows; @lt_lows ||= [].max_size!(lt_period) end
+        def compute_midpoint
+          p0.midpoint = (p0.high_price + p0.low_price) * 0.5
+        end
 
         def compute_bands
-          st_highs << p0.high_price
-          st_lows << p0.low_price
-          mt_highs << p0.high_price
-          mt_lows << p0.low_price
-          lt_highs << p0.high_price
-          lt_lows << p0.low_price
+          period_points(micro_period).tap do |period_points|
+            p0.l1 = period_points.map(&:low_price).min
+            p0.h1 = period_points.map(&:high_price).max
+          end
 
-          p0.h1 = @st_highs.maximum
-          p0.l1 = @st_lows.minimum
+          period_points(min_period).tap do |period_points|
+            p0.l2 = period_points.map(&:low_price).min
+            p0.h2 = period_points.map(&:high_price).max
+          end
 
-          p0.h2 = @mt_highs.maximum
-          p0.l2 = @mt_lows.minimum
+          period_points(half_period).tap do |period_points|
+            p0.l3 = period_points.map(&:low_price).min
+            p0.h3 = period_points.map(&:high_price).max
+          end
 
-          p0.h3 = @lt_highs.maximum
-          p0.l3 = @lt_lows.minimum
+          period_points(max_period).tap do |period_points|
+            p0.l4 = period_points.map(&:low_price).min
+            p0.h4 = period_points.map(&:high_price).max
+          end
         end
       end
     end

--- a/lib/quant/indicators/pivots/fibbonacci.rb
+++ b/lib/quant/indicators/pivots/fibbonacci.rb
@@ -4,18 +4,19 @@ module Quant
       class Fibbonacci < Pivot
         register name: :fibbonacci
 
-        def averaging_period
-          half_period
-        end
-
-        def fibbonacci_series
-          [0.146, 0.236, 0.382, 0.5, 0.618, 0.786, 1.0, 1.146]
-        end
+        FIBBONACCI_SERIES = [0.146, 0.236, 0.382, 0.5, 0.618, 0.786, 1.0, 1.146].freeze
 
         def compute_bands
-          fibbonacci_series.each_with_index do |ratio, index|
-            p0[index + 1] = p0.midpoint + ratio * p0.avg_range
-            p0[-index - 1] = p0.midpoint - ratio * p0.avg_range
+          period_points(adaptive_period).tap do |period_points|
+            highest = period_points.map(&:high_price).max
+            lowest = period_points.map(&:low_price).min
+            p0.range = highest - lowest
+            p0.midpoint = (highest + lowest) * 0.5
+          end
+
+          FIBBONACCI_SERIES.each_with_index do |ratio, index|
+            p0[index + 1] = p0.midpoint + ratio * p0.range
+            p0[-index - 1] = p0.midpoint - ratio * p0.range
           end
         end
       end

--- a/lib/quant/indicators/pivots/keltner.rb
+++ b/lib/quant/indicators/pivots/keltner.rb
@@ -10,33 +10,24 @@ module Quant
         end
 
         def scale
-          5.0
-        end
-
-        def alpha
-          bars_to_alpha(min_period)
+          3.0
         end
 
         def compute_midpoint
+          alpha = bars_to_alpha(min_period)
           p0.midpoint = alpha * p0.input + (1 - alpha) * p1.midpoint
         end
 
+        KELTNER_SERIES = [0.236, 0.382, 0.500, 0.618, 0.786, 1.0].freeze
+
         def compute_bands
-          atr_value = atr_point.slow * scale
+          atr_value = atr_point.value * scale
 
-          p0.h6 = p0.midpoint + 1.000 * atr_value
-          p0.h5 = p0.midpoint + 0.786 * atr_value
-          p0.h4 = p0.midpoint + 0.618 * atr_value
-          p0.h3 = p0.midpoint + 0.500 * atr_value
-          p0.h2 = p0.midpoint + 0.382 * atr_value
-          p0.h1 = p0.midpoint + 0.236 * atr_value
-
-          p0.l1 = p0.midpoint - 0.236 * atr_value
-          p0.l2 = p0.midpoint - 0.382 * atr_value
-          p0.l3 = p0.midpoint - 0.500 * atr_value
-          p0.l4 = p0.midpoint - 0.618 * atr_value
-          p0.l5 = p0.midpoint - 0.786 * atr_value
-          p0.l6 = p0.midpoint - 1.000 * atr_value
+          KELTNER_SERIES.each_with_index do |ratio, index|
+            offset = ratio * atr_value
+            p0[index + 1] = p0.midpoint + offset
+            p0[-index - 1] = p0.midpoint - offset
+          end
         end
       end
     end

--- a/lib/quant/indicators/pivots/murrey.rb
+++ b/lib/quant/indicators/pivots/murrey.rb
@@ -14,20 +14,13 @@ module Quant
           p0.midpoint = p0.lowest + (p0.input * 4.0)
         end
 
-        def compute_bands
-          p0.h6 = p0.midpoint + p0.input * 6.0
-          p0.h5 = p0.midpoint + p0.input * 5.0
-          p0.h4 = p0.midpoint + p0.input * 4.0
-          p0.h3 = p0.midpoint + p0.input * 3.0
-          p0.h2 = p0.midpoint + p0.input * 2.0
-          p0.h1 = p0.midpoint + p0.input * 1.0
+        MURREY_SERIES = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0].freeze
 
-          p0.l1 = p0.midpoint - p0.input * 1.0
-          p0.l2 = p0.midpoint - p0.input * 2.0
-          p0.l3 = p0.midpoint - p0.input * 3.0
-          p0.l4 = p0.midpoint - p0.input * 4.0
-          p0.l5 = p0.midpoint - p0.input * 5.0
-          p0.l6 = p0.midpoint - p0.input * 6.0
+        def compute_bands
+          MURREY_SERIES.each_with_index do |ratio, index|
+            p0[index + 1] = p0.midpoint + p0.input * ratio
+            p0[-index - 1] = p0.midpoint - p0.input * ratio
+          end
         end
       end
     end

--- a/lib/quant/indicators/pivots/pivot.rb
+++ b/lib/quant/indicators/pivots/pivot.rb
@@ -2,11 +2,9 @@ module Quant
   module Indicators
     module Pivots
       class PivotPoint < IndicatorPoint
-        attribute :high_price
         attribute :avg_high, default: :high_price
         attribute :highest, default: :input
 
-        attribute :low_price
         attribute :avg_low, default: :low_price
         attribute :lowest, default: :input
 
@@ -93,8 +91,6 @@ module Quant
 
         def compute_extents
           period_midpoints.tap do |midpoints|
-            p0.high_price = t0.high_price
-            p0.low_price = t0.low_price
             p0.highest = midpoints.max
             p0.lowest = midpoints.min
             p0.range = p0.high_price - p0.low_price

--- a/lib/quant/indicators/pivots/pivot.rb
+++ b/lib/quant/indicators/pivots/pivot.rb
@@ -59,7 +59,7 @@ module Quant
         end
 
         def period
-          dc_period
+          adaptive_period
         end
 
         def averaging_period
@@ -68,6 +68,10 @@ module Quant
 
         def period_midpoints
           period_points(period).map(&:midpoint)
+        end
+
+        def smoothed_average_midpoint
+          three_pole_super_smooth :input, previous: :midpoint, period: averaging_period
         end
 
         def compute
@@ -94,9 +98,9 @@ module Quant
             p0.highest = midpoints.max
             p0.lowest = midpoints.min
             p0.range = p0.high_price - p0.low_price
-            p0.avg_low = super_smoother(:low_price, previous: :avg_low, period: averaging_period)
-            p0.avg_high = super_smoother(:high_price, previous: :avg_high, period: averaging_period)
-            p0.avg_range = super_smoother(:range, previous: :avg_range, period: averaging_period)
+            p0.avg_low = three_pole_super_smooth(:low_price, previous: :avg_low, period: averaging_period)
+            p0.avg_high = three_pole_super_smooth(:high_price, previous: :avg_high, period: averaging_period)
+            p0.avg_range = three_pole_super_smooth(:range, previous: :avg_range, period: averaging_period)
           end
         end
       end

--- a/lib/quant/version.rb
+++ b/lib/quant/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Quant
-  VERSION = "0.3.2"
+  VERSION = "0.3.3"
 end

--- a/lib/quantitative.rb
+++ b/lib/quantitative.rb
@@ -18,6 +18,7 @@ module Quant
   include Config
   include Experimental
 end
+Quantitative = Quant
 
 # Configure Zeitwerk to autoload the Quant module.
 loader = Zeitwerk::Loader.for_gem

--- a/spec/lib/quant/indicators/indicator_point_spec.rb
+++ b/spec/lib/quant/indicators/indicator_point_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Quant::Indicators::IndicatorPoint do
 
   describe "attributes" do
     let(:indicator) { instance_double(Quant::Indicators::Indicator, min_period: 1) }
-    let(:tick) { instance_double(Quant::Ticks::OHLC, oc2: 3.0, open_price: 2.0, volume: 100) }
+    let(:tick) { instance_double(Quant::Ticks::OHLC, oc2: 3.0, low_price: 1.0, high_price: 8.0, open_price: 2.0, volume: 100) }
     let(:source) { :oc2 }
 
     it { expect(subject.tick).to eq(tick) }
@@ -13,5 +13,9 @@ RSpec.describe Quant::Indicators::IndicatorPoint do
     it { expect(subject.input).to eq(3.0) }
     it { expect(subject.to_h).to eq("in" => 3.0, "src" => :oc2) }
     it { expect(subject.min_period).to eq(1) }
+    it { expect(subject.high_price).to eq(8.0) }
+    it { expect(subject.low_price).to eq(1.0) }
+    it { expect(subject.oc2).to eq(3.0) }
+    it { expect(subject.volume).to eq(100) }
   end
 end

--- a/spec/lib/quant/indicators/pivots/atr_spec.rb
+++ b/spec/lib/quant/indicators/pivots/atr_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe Quant::Indicators::Pivots::Atr do
   it { expect(subject.values.map(&:input)).to eq([3.0, 6.0, 12.0, 24.0]) }
 
   context "bands" do
-    it { expect(subject.values.map{ |v| v.h6.round(3) }).to eq([3.0, 3.614, 5.668, 10.757]) }
-    it { expect(subject.values.map{ |v| v.h1.round(3) }).to eq([3.0, 3.435, 4.79, 8.068]) }
-    it { expect(subject.values.map{ |v| v.midpoint.round(3) }).to eq([3.0, 3.38, 4.519, 7.238]) }
+    it { expect(subject.values.map{ |v| v.h6.round(3) }).to eq([3.0, 4.09, 7.75, 16.4]) }
+    it { expect(subject.values.map{ |v| v.h1.round(3) }).to eq([3.0, 3.56, 5.572, 10.509]) }
+    it { expect(subject.values.map{ |v| v.midpoint.round(3) }).to eq([3.0, 3.397, 4.899, 8.689]) }
     it { expect(subject.values.map{ |v| v.h0.round(3) }).to eq(subject.values.map{ |v| v.midpoint.round(3) }) }
-    it { expect(subject.values.map{ |v| v.l1.round(3) }).to eq([3.0, 3.325, 4.248, 6.407]) }
-    it { expect(subject.values.map{ |v| v.l6.round(3) }).to eq([3.0, 3.146, 3.37, 3.719]) }
+    it { expect(subject.values.map{ |v| v.l1.round(3) }).to eq([3.0, 3.234, 4.226, 6.869]) }
+    it { expect(subject.values.map{ |v| v.l6.round(3) }).to eq([3.0, 2.704, 2.048, 0.978]) }
   end
 
   context "bands do not intersect each other" do

--- a/spec/lib/quant/indicators/pivots/bollinger_spec.rb
+++ b/spec/lib/quant/indicators/pivots/bollinger_spec.rb
@@ -11,15 +11,15 @@ RSpec.describe Quant::Indicators::Pivots::Bollinger do
   it { expect(subject.series.size).to eq(4) }
   it { expect(subject.ticks).to be_a(Array) }
   it { expect(subject.values.map(&:input)).to eq([3.0, 6.0, 12.0, 24.0]) }
-  it { expect(subject.values.map{ |v| v.std_dev.round(3) }).to eq([0.0, 2.052, 5.22, 10.905]) }
+  it { expect(subject.values.map{ |v| v.std_dev.round(3) }).to eq([0.0, 1.985, 4.985, 10.365]) }
 
   context "bands" do
-    it { expect(subject.values.map{ |v| v.h6.round(3) }).to eq([3.0, 8.23, 16.41, 31.148]) }
-    it { expect(subject.values.map{ |v| v.h1.round(3) }).to eq([3.0, 5.152, 8.58, 14.791]) }
-    it { expect(subject.values.map{ |v| v.midpoint.round(3) }).to eq([3.0, 3.1, 3.36, 3.886]) }
+    it { expect(subject.values.map{ |v| v.h6.round(3) }).to eq([3.0, 8.162, 16.168, 30.624]) }
+    it { expect(subject.values.map{ |v| v.h1.round(3) }).to eq([3.0, 5.185, 8.691, 15.077]) }
+    it { expect(subject.values.map{ |v| v.midpoint.round(3) }).to eq([3.0, 3.2, 3.707, 4.712]) }
     it { expect(subject.values.map{ |v| v.h0.round(3) }).to eq(subject.values.map{ |v| v.midpoint.round(3) }) }
-    it { expect(subject.values.map{ |v| v.l1.round(3) }).to eq([3.0, 1.048, -1.86, -7.019]) }
-    it { expect(subject.values.map{ |v| v.l6.round(3) }).to eq([3.0, -2.03, -9.69, -23.376]) }
+    it { expect(subject.values.map{ |v| v.l1.round(3) }).to eq([3.0, 1.215, -1.278, -5.652]) }
+    it { expect(subject.values.map{ |v| v.l6.round(3) }).to eq([3.0, -1.762, -8.755, -21.199]) }
   end
 
   context "bands do not intersect each other" do

--- a/spec/lib/quant/indicators/pivots/camarilla_spec.rb
+++ b/spec/lib/quant/indicators/pivots/camarilla_spec.rb
@@ -15,18 +15,18 @@ RSpec.describe Quant::Indicators::Pivots::Camarilla do
   context "bands" do
     it { expect(subject.values.map{ |v| v.range.round(3) }).to eq([2.0, 4.0, 8.0, 16.0]) }
     it { expect(subject.values.map{ |v| v.h6.round(3) }).to eq([8.0, 16.0, 32.0, 64.0]) }
-    it { expect(subject.values.map{ |v| v.h5.round(3) }).to eq([5.227, 10.454, 20.909, 41.818]) }
-    it { expect(subject.values.map{ |v| v.h4.round(3) }).to eq([3.3, 6.6, 13.2, 26.4]) }
-    it { expect(subject.values.map{ |v| v.h3.round(3) }).to eq([1.65, 3.3, 6.6, 13.2]) }
-    it { expect(subject.values.map{ |v| v.h2.round(3) }).to eq([1.1, 2.2, 4.4, 8.8]) }
-    it { expect(subject.values.map{ |v| v.h1.round(3) }).to eq([0.55, 1.1, 2.2, 4.4]) }
-    it { expect(subject.values.map{ |v| v.midpoint.round(3) }).to eq([4.0, 8.0, 16.0, 32.0]) }
+    it { expect(subject.values.map{ |v| v.h5.round(3) }).to eq([7.84, 15.68, 31.36, 62.72]) }
+    it { expect(subject.values.map{ |v| v.h4.round(3) }).to eq([7.0, 14.0, 28.0, 56.0]) }
+    it { expect(subject.values.map{ |v| v.h3.round(3) }).to eq([6.5, 13.0, 26.0, 52.0]) }
+    it { expect(subject.values.map{ |v| v.h2.round(3) }).to eq([6.334, 12.668, 25.336, 50.672]) }
+    it { expect(subject.values.map{ |v| v.h1.round(3) }).to eq([6.166, 12.332, 24.664, 49.328]) }
+    it { expect(subject.values.map{ |v| v.midpoint.round(3) }).to eq([3.333, 6.667, 13.333, 26.667]) }
     it { expect(subject.values.map{ |v| v.h0.round(3) }).to eq(subject.values.map{ |v| v.midpoint.round(3) }) }
-    it { expect(subject.values.map{ |v| v.l1.round(3) }).to eq([0.183, 0.367, 0.733, 1.467]) }
-    it { expect(subject.values.map{ |v| v.l2.round(3) }).to eq([0.367, 0.733, 1.467, 2.933]) }
-    it { expect(subject.values.map{ |v| v.l3.round(3) }).to eq([0.55, 1.1, 2.2, 4.4]) }
-    it { expect(subject.values.map{ |v| v.l4.round(3) }).to eq([1.1, 2.2, 4.4, 8.8]) }
-    it { expect(subject.values.map{ |v| v.l5.round(3) }).to eq([1.742, 3.485, 6.97, 13.939]) }
+    it { expect(subject.values.map{ |v| v.l1.round(3) }).to eq([1.834, 3.668, 7.336, 14.672]) }
+    it { expect(subject.values.map{ |v| v.l2.round(3) }).to eq([1.666, 3.332, 6.664, 13.328]) }
+    it { expect(subject.values.map{ |v| v.l3.round(3) }).to eq([1.5, 3.0, 6.0, 12.0]) }
+    it { expect(subject.values.map{ |v| v.l4.round(3) }).to eq([1.0, 2.0, 4.0, 8.0]) }
+    it { expect(subject.values.map{ |v| v.l5.round(3) }).to eq([0.16, 0.32, 0.64, 1.28]) }
     it { expect(subject.values.map{ |v| v.l6.round(3) }).to eq([0.0, 0.0, 0.0, 0.0]) }
   end
 end

--- a/spec/lib/quant/indicators/pivots/classic_spec.rb
+++ b/spec/lib/quant/indicators/pivots/classic_spec.rb
@@ -12,29 +12,14 @@ RSpec.describe Quant::Indicators::Pivots::Classic do
   it { expect(subject.ticks).to be_a(Array) }
   it { expect(subject.values.map(&:input)).to eq([3.0, 6.0, 12.0, 24.0]) }
 
-  context "extents" do
-    it { expect(subject.values.map{ |v| v.avg_low.round(3) }).to eq([2.0, 2.253, 3.013, 4.825]) }
-    it { expect(subject.values.map{ |v| v.avg_high.round(3) }).to eq([4.0, 4.506, 6.026, 9.65]) }
-    it { expect(subject.values.map{ |v| v.avg_range.round(3) }).to eq([0.506, 1.138, 1.897, 4.148]) }
-  end
-
   context "bands" do
-    it { expect(subject.values.map{ |v| v.h3.round(3) }).to eq([4.013, 5.655, 8.314, 15.533]) }
-    it { expect(subject.values.map{ |v| v.h2.round(3) }).to eq([3.506, 4.518, 6.417, 11.385]) }
-    it { expect(subject.values.map{ |v| v.h1.round(3) }).to eq([4.0, 4.506, 6.026, 9.65]) }
-    it { expect(subject.values.map{ |v| v.midpoint.round(3) }).to eq([3.0, 3.38, 4.519, 7.238]) }
+    it { expect(subject.values.map{ |v| v.h3.round(3) }).to eq([3.529, 4.915, 9.239, 18.991]) }
+    it { expect(subject.values.map{ |v| v.h2.round(3) }).to eq([3.265, 4.156, 7.069, 13.84]) }
+    it { expect(subject.values.map{ |v| v.h1.round(3) }).to eq([4.0, 4.529, 6.532, 11.585]) }
+    it { expect(subject.values.map{ |v| v.midpoint.round(3) }).to eq([3.0, 3.397, 4.899, 8.689]) }
     it { expect(subject.values.map{ |v| v.h0.round(3) }).to eq(subject.values.map{ |v| v.midpoint.round(3) }) }
-    it { expect(subject.values.map{ |v| v.l1.round(3) }).to eq([2.0, 2.253, 3.013, 4.825]) }
-    it { expect(subject.values.map{ |v| v.l2.round(3) }).to eq([2.494, 2.242, 2.622, 3.09]) }
-    it { expect(subject.values.map{ |v| v.l3.round(3) }).to eq([1.987, 1.104, 0.724, -1.058]) }
-  end
-
-  context "bands do not intersect each other" do
-    %i[h3 h2 h1 midpoint l1 l2 l3].each_cons(2) do |above_band, below_band|
-      it "band #{above_band.inspect} is above band #{below_band.inspect}" do
-        compare_values = subject.values.drop(1) # first value is often zero, which isn't truthy for "positive?"
-        expect(compare_values.map{ |v| v.send(above_band) - v.send(below_band) }).to all be_positive
-      end
-    end
+    it { expect(subject.values.map{ |v| v.l1.round(3) }).to eq([2.0, 2.265, 3.266, 5.793]) }
+    it { expect(subject.values.map{ |v| v.l2.round(3) }).to eq([2.735, 2.638, 2.729, 3.538]) }
+    it { expect(subject.values.map{ |v| v.l3.round(3) }).to eq([2.471, 1.879, 0.559, -1.613]) }
   end
 end

--- a/spec/lib/quant/indicators/pivots/demark_spec.rb
+++ b/spec/lib/quant/indicators/pivots/demark_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe Quant::Indicators::Pivots::Demark do
   it { is_expected.to be_a(described_class) }
   it { expect(subject.series.size).to eq(4) }
   it { expect(subject.ticks).to be_a(Array) }
-  it { expect(subject.values.map{ |v| v.input.round(3) }).to eq([14.0, 21.253, 39.011, 76.213]) }
+  it { expect(subject.values.map{ |v| v.input.round(3) }).to eq([14.0, 23.648, 47.348, 95.779]) }
 
   context "bands" do
-    it { expect(subject.values.map{ |v| v.h1.round(3) }).to eq([3.0, 3.756, 5.621, 9.911]) }
-    it { expect(subject.values.map{ |v| v.midpoint.round(3) }).to eq([3.5, 4.09, 5.726, 9.589]) }
+    it { expect(subject.values.map{ |v| v.h1.round(3) }).to eq([3.0, 4.449, 8.724, 17.792]) }
+    it { expect(subject.values.map{ |v| v.midpoint.round(3) }).to eq([3.5, 4.862, 9.271, 18.968]) }
     it { expect(subject.values.map{ |v| v.h0.round(3) }).to eq(subject.values.map{ |v| v.midpoint.round(3) }) }
-    it { expect(subject.values.map{ |v| v.l1.round(3) }).to eq([5.0, 5.968, 8.536, 14.544]) }
+    it { expect(subject.values.map{ |v| v.l1.round(3) }).to eq([5.0, 7.087, 13.633, 27.863]) }
   end
 end

--- a/spec/lib/quant/indicators/pivots/donchian_spec.rb
+++ b/spec/lib/quant/indicators/pivots/donchian_spec.rb
@@ -14,23 +14,14 @@ RSpec.describe Quant::Indicators::Pivots::Donchian do
 
   # TODO: Need a longer series run to test this properly
   context "bands" do
+    it { expect(subject.values.map{ |v| v.h4.round(3) }).to eq([4.0, 8.0, 16.0, 32.0]) }
     it { expect(subject.values.map{ |v| v.h3.round(3) }).to eq([4.0, 8.0, 16.0, 32.0]) }
     it { expect(subject.values.map{ |v| v.h2.round(3) }).to eq([4.0, 8.0, 16.0, 32.0]) }
     it { expect(subject.values.map{ |v| v.h1.round(3) }).to eq([4.0, 8.0, 16.0, 32.0]) }
     it { expect(subject.values.map{ |v| v.midpoint.round(3) }).to eq([3.0, 6.0, 12.0, 24.0]) }
     it { expect(subject.values.map{ |v| v.h0.round(3) }).to eq(subject.values.map{ |v| v.midpoint.round(3) }) }
-    it { expect(subject.values.map{ |v| v.l1.round(3) }).to eq([2.0, 2.0, 2.0, 2.0]) }
+    it { expect(subject.values.map{ |v| v.l1.round(3) }).to eq([2.0, 2.0, 2.0, 4.0]) }
     it { expect(subject.values.map{ |v| v.l2.round(3) }).to eq([2.0, 2.0, 2.0, 2.0]) }
     it { expect(subject.values.map{ |v| v.l3.round(3) }).to eq([2.0, 2.0, 2.0, 2.0]) }
-  end
-
-  # TODO: Need a longer series run to test this properly
-  xcontext "bands do not intersect each other" do
-    %i[h3 h2 h1 midpoint l1 l2 l3].each_cons(2) do |above_band, below_band|
-      it "band #{above_band.inspect} is above band #{below_band.inspect}" do
-        compare_values = subject.values.drop(1) # first value is often zero, which isn't truthy for "positive?"
-        expect(compare_values.map{ |v| v.send(above_band) - v.send(below_band) }).to all be_positive
-      end
-    end
   end
 end

--- a/spec/lib/quant/indicators/pivots/fibbonacci_spec.rb
+++ b/spec/lib/quant/indicators/pivots/fibbonacci_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe Quant::Indicators::Pivots::Fibbonacci do
   it { expect(subject.values.map(&:input)).to eq([3.0, 6.0, 12.0, 24.0]) }
 
   context "bands" do
-    it { expect(subject.values.map{ |v| v.h6.round(3) }).to eq([3.063, 6.156, 12.251, 24.597]) }
-    it { expect(subject.values.map{ |v| v.h1.round(3) }).to eq([3.012, 6.029, 12.047, 24.111]) }
-    it { expect(subject.values.map{ |v| v.midpoint.round(3) }).to eq([3.0, 6.0, 12.0, 24.0]) }
+    it { expect(subject.values.map{ |v| v.h6.round(3) }).to eq([4.572, 9.716, 20.004, 40.58]) }
+    it { expect(subject.values.map{ |v| v.h1.round(3) }).to eq([3.292, 5.876, 11.044, 21.38]) }
+    it { expect(subject.values.map{ |v| v.midpoint.round(3) }).to eq([3.0, 5.0, 9.0, 17.0]) }
     it { expect(subject.values.map{ |v| v.h0.round(3) }).to eq(subject.values.map{ |v| v.midpoint.round(3) }) }
-    it { expect(subject.values.map{ |v| v.l1.round(3) }).to eq([2.988, 5.971, 11.953, 23.889]) }
-    it { expect(subject.values.map{ |v| v.l6.round(3) }).to eq([2.937, 5.844, 11.749, 23.403]) }
+    it { expect(subject.values.map{ |v| v.l1.round(3) }).to eq([2.708, 4.124, 6.956, 12.62]) }
+    it { expect(subject.values.map{ |v| v.l6.round(3) }).to eq([1.428, 0.284, -2.004, -6.58]) }
   end
 
   context "bands do not intersect each other" do

--- a/spec/lib/quant/indicators/pivots/keltner_spec.rb
+++ b/spec/lib/quant/indicators/pivots/keltner_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe Quant::Indicators::Pivots::Keltner do
   it { expect(subject.values.map(&:input)).to eq([3.0, 6.0, 12.0, 24.0]) }
 
   context "bands" do
-    it { expect(subject.values.map{ |v| v.h6.round(3) }).to eq([3.0, 3.779, 6.231, 12.041]) }
-    it { expect(subject.values.map{ |v| v.h1.round(3) }).to eq([3.0, 3.601, 5.354, 9.353]) }
+    it { expect(subject.values.map{ |v| v.h6.round(3) }).to eq([3.0, 4.238, 7.934, 16.233]) }
+    it { expect(subject.values.map{ |v| v.h1.round(3) }).to eq([3.0, 3.709, 5.756, 10.342]) }
     it { expect(subject.values.map{ |v| v.midpoint.round(3) }).to eq([3.0, 3.545, 5.083, 8.522]) }
     it { expect(subject.values.map{ |v| v.h0.round(3) }).to eq(subject.values.map{ |v| v.midpoint.round(3) }) }
-    it { expect(subject.values.map{ |v| v.l1.round(3) }).to eq([3.0, 3.49, 4.812, 7.692]) }
-    it { expect(subject.values.map{ |v| v.l6.round(3) }).to eq([3.0, 3.312, 3.934, 5.003]) }
+    it { expect(subject.values.map{ |v| v.l1.round(3) }).to eq([3.0, 3.382, 4.41, 6.702]) }
+    it { expect(subject.values.map{ |v| v.l6.round(3) }).to eq([3.0, 2.853, 2.231, 0.811]) }
   end
 
   context "bands do not intersect each other" do

--- a/spec/lib/quant/indicators/pivots/pivot_spec.rb
+++ b/spec/lib/quant/indicators/pivots/pivot_spec.rb
@@ -7,6 +7,15 @@ RSpec.describe Quant::Indicators::Pivots::Pivot do
 
   subject { described_class.new(series:, source:) }
 
+  context "extents" do
+    it { expect(subject.values.map{ |v| v.highest.round(3) }).to eq([3.0, 6.0, 12.0, 24.0]) }
+    it { expect(subject.values.map{ |v| v.avg_high.round(3) }).to eq([4.0, 4.529, 6.532, 11.585]) }
+    it { expect(subject.values.map{ |v| v.lowest.round(3) }).to eq([3.0, 3.0, 3.0, 3.0]) }
+    it { expect(subject.values.map{ |v| v.low_price.round(3) }).to eq([2.0, 4.0, 8.0, 16.0]) }
+    it { expect(subject.values.map{ |v| v.high_price.round(3) }).to eq([4.0, 8.0, 16.0, 32.0]) }
+    it { expect(subject.values.map{ |v| v.range.round(3) }).to eq([2.0, 4.0, 8.0, 16.0]) }
+  end
+
   it { is_expected.to be_a(described_class) }
   it { expect(subject.series.size).to eq(4) }
   it { expect(subject.ticks).to be_a(Array) }
@@ -20,7 +29,7 @@ RSpec.describe Quant::Indicators::Pivots::Pivot do
   it { expect(subject.values.map(&:low_price)).to eq([2.0, 4.0, 8.0, 16.0]) }
   it { expect(subject.values.map(&:range)).to eq([2.0, 4.0, 8.0, 16.0]) }
 
-  it { expect(subject.values.map{ |v| v.avg_high.round(3) }).to eq([4.0, 4.506, 6.026, 9.65]) }
-  it { expect(subject.values.map{ |v| v.avg_low.round(3) }).to eq([2.0, 2.253, 3.013, 4.825]) }
-  it { expect(subject.values.map{ |v| v.avg_range.round(3) }).to eq([0.506, 1.138, 1.897, 4.148]) }
+  it { expect(subject.values.map{ |v| v.avg_high.round(3) }).to eq([4.0, 4.529, 6.532, 11.585]) }
+  it { expect(subject.values.map{ |v| v.avg_low.round(3) }).to eq([2.0, 2.265, 3.266, 5.793]) }
+  it { expect(subject.values.map{ |v| v.avg_range.round(3) }).to eq([0.265, 0.759, 2.17, 5.151]) }
 end

--- a/spec/lib/quant/indicators/pivots/traditional_spec.rb
+++ b/spec/lib/quant/indicators/pivots/traditional_spec.rb
@@ -13,15 +13,6 @@ RSpec.describe Quant::Indicators::Pivots::Traditional do
   it { expect(subject.ticks.map(&:oc2)).to eq([3.0, 6.0, 12.0, 24.0]) }
   it { expect(subject.values.map(&:input)).to eq([3.0, 6.0, 12.0, 24.0]) }
 
-  context "extents" do
-    it { expect(subject.values.map{ |v| v.highest.round(3) }).to eq([3.0, 6.0, 12.0, 24.0]) }
-    it { expect(subject.values.map{ |v| v.avg_high.round(3) }).to eq([4.0, 4.506, 6.026, 9.65]) }
-    it { expect(subject.values.map{ |v| v.lowest.round(3) }).to eq([3.0, 3.0, 3.0, 3.0]) }
-    it { expect(subject.values.map{ |v| v.low_price.round(3) }).to eq([2.0, 4.0, 8.0, 16.0]) }
-    it { expect(subject.values.map{ |v| v.high_price.round(3) }).to eq([4.0, 8.0, 16.0, 32.0]) }
-    it { expect(subject.values.map{ |v| v.range.round(3) }).to eq([2.0, 4.0, 8.0, 16.0]) }
-  end
-
   # Woodie's calculated bands are erratic as-written. The following tests are marked
   # as pending until the correct formula is determined.
   context "bands" do

--- a/spec/lib/quant/indicators/pivots/woodie_spec.rb
+++ b/spec/lib/quant/indicators/pivots/woodie_spec.rb
@@ -13,14 +13,6 @@ RSpec.describe Quant::Indicators::Pivots::Woodie do
   it { expect(subject.ticks.map(&:oc2)).to eq([3.0, 6.0, 12.0, 24.0]) }
   it { expect(subject.values.map(&:input)).to eq([2.5, 3.5, 7.0, 14.0]) }
 
-  context "extents" do
-    it { expect(subject.values.map{ |v| v.highest.round(3) }).to eq([3.0, 6.0, 12.0, 24.0]) }
-    it { expect(subject.values.map{ |v| v.avg_high.round(3) }).to eq([4.0, 4.506, 6.026, 9.65]) }
-    it { expect(subject.values.map{ |v| v.lowest.round(3) }).to eq([3.0, 2.5, 2.5, 2.5]) }
-    it { expect(subject.values.map{ |v| v.low_price.round(3) }).to eq([2.0, 4.0, 8.0, 16.0]) }
-    it { expect(subject.values.map{ |v| v.range.round(3) }).to eq([2.0, 4.0, 8.0, 16.0]) }
-  end
-
   # Woodie's calculated bands are erratic as-written. The following tests are marked
   # as pending until the correct formula is determined.
   context "bands" do
@@ -34,14 +26,5 @@ RSpec.describe Quant::Indicators::Pivots::Woodie do
     it { expect(subject.values.map{ |v| v.l2.round(3) }).to eq([0.5, -0.5, -1.0, -2.0]) }
     it { expect(subject.values.map{ |v| v.l3.round(3) }).to eq([-1.0, 1.0, 2.0, 4.0]) }
     it { expect(subject.values.map{ |v| v.l4.round(3) }).to eq([-3.0, -3.0, -6.0, -12.0]) }
-  end
-
-  xcontext "bands do not intersect each other" do
-    %i[h4 h3 h2 h1 midpoint l1 l2 l3 l4].each_cons(2) do |above_band, below_band|
-      it "band #{above_band.inspect} is above band #{below_band.inspect}" do
-        compare_values = subject.values.drop(1) # first value is often zero, which isn't truthy for "positive?"
-        expect(compare_values.map{ |v| v.send(above_band) - v.send(below_band) }).to all be_positive
-      end
-    end
   end
 end


### PR DESCRIPTION
Pivot Indicators were visually inspected by graphing results and reviewing for accuracy.  Many were adjusted and their implementations also improved once adjusted.

Also added `#trades` to the `Ticks::OHLC` class as some data feeds provide number of trades in their dataset.