### PR TITLE
v0.4.1: Fix fractional volume truncation in OHLC and Spot ticks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 # rspec failure tracking
 .rspec_status
 *.gem
+
+# Serena AI assistant workspace
+.serena/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    quantitative (0.4.0)
+    quantitative (0.4.1)
       csv
       oj (~> 3.10)
       zeitwerk (~> 2.6)

--- a/lib/quant/ticks/ohlc.rb
+++ b/lib/quant/ticks/ohlc.rb
@@ -45,8 +45,11 @@ module Quant
         @low_price = low_price.to_f
         @close_price = close_price.to_f
 
-        @base_volume = (volume || base_volume).to_i
-        @target_volume = (target_volume || @base_volume).to_i
+        # Volumes are floats, not ints — crypto markets and many futures markets express
+        # fractional base/target volumes routinely (e.g., 0.12345 BTC). Existing specs already
+        # asserted Float values (`eq(2.0)`); a prior `.to_i` regression silently truncated.
+        @base_volume = (volume || base_volume).to_f
+        @target_volume = (target_volume || @base_volume).to_f
         @trades = trades.to_i
 
         @green = green.nil? ? compute_green : green

--- a/lib/quant/ticks/spot.rb
+++ b/lib/quant/ticks/spot.rb
@@ -39,8 +39,12 @@ module Quant
         @close_timestamp = extract_time(timestamp || close_timestamp || Quant.current_time)
         @open_timestamp = @close_timestamp
 
-        @base_volume = (volume || base_volume).to_i
-        @target_volume = (target_volume || @base_volume).to_i
+        # Volumes are floats, not ints — crypto markets and many futures markets express
+        # fractional base/target volumes routinely (e.g., 0.12345 BTC). Existing specs already
+        # asserted Float values (`eq(2.0)`); a prior `.to_i` regression silently truncated.
+        # See OHLC for the same fix.
+        @base_volume = (volume || base_volume).to_f
+        @target_volume = (target_volume || @base_volume).to_f
 
         @trades = trades.to_i
         super()

--- a/lib/quant/version.rb
+++ b/lib/quant/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Quant
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end

--- a/quantitative.gemspec
+++ b/quantitative.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
-  spec.metadata["changelog_uri"] = spec.homepage
+  spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/main/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/spec/lib/quant/ticks/ohlc_spec.rb
+++ b/spec/lib/quant/ticks/ohlc_spec.rb
@@ -71,6 +71,23 @@ RSpec.describe Quant::Ticks::OHLC do
       end
     end
 
+    # Regression guard: volumes must be Float, not Integer-truncated. Crypto markets
+    # express fractional volumes routinely (e.g., 0.12345 BTC); a prior `.to_i` coercion
+    # in #initialize silently truncated them and passed loose `eq(2.0)` assertions
+    # because Ruby's `==` coerces `2 == 2.0`. This block asserts both the value AND the
+    # class so future regressions fail loudly.
+    context "with fractional crypto-style volumes" do
+      let(:json) do
+        { "ot" => open_time.to_i, "ct" => close_time, "o" => 1.0,
+          "bv" => 0.12345, "tv" => 5_678.901_234 }
+      end
+
+      it { expect(subject.base_volume).to eq(0.12345) }
+      it { expect(subject.target_volume).to eq(5_678.901_234) }
+      it { expect(subject.base_volume).to be_a(Float) }
+      it { expect(subject.target_volume).to be_a(Float) }
+    end
+
     context "without volume" do
       let(:json) { { "ot" => open_time.to_i, "ct" => close_time, "o" => 1.0 } }
 

--- a/spec/lib/quant/ticks/ohlc_spec.rb
+++ b/spec/lib/quant/ticks/ohlc_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Quant::Ticks::OHLC do
         )
       end
 
-      it { expect(tick.inspect).to eq("#<Quant::Ticks::OHLC ct=2024-01-15T08:30:05Z o=1.0 h=2.0 l=3.0 c=4.0 v=88>") }
+      it { expect(tick.inspect).to eq("#<Quant::Ticks::OHLC ct=2024-01-15T08:30:05Z o=1.0 h=2.0 l=3.0 c=4.0 v=88.0>") }
     end
 
     describe "equality" do

--- a/spec/lib/quant/ticks/spot_spec.rb
+++ b/spec/lib/quant/ticks/spot_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Quant::Ticks::Spot do
       )
     end
 
-    it { expect(tick.inspect).to eq("#<Quant::Ticks::Spot ct=2024-01-15 08:30:05 UTC c=1.25 v=88>") }
+    it { expect(tick.inspect).to eq("#<Quant::Ticks::Spot ct=2024-01-15 08:30:05 UTC c=1.25 v=88.0>") }
   end
 
   describe "#corresponding?" do

--- a/spec/lib/quant/ticks/spot_spec.rb
+++ b/spec/lib/quant/ticks/spot_spec.rb
@@ -31,6 +31,24 @@ RSpec.describe Quant::Ticks::Spot do
         expect(subject.target_volume).to eq(0.0)
       end
     end
+
+    # Regression guard: volumes must be Float, not Integer-truncated. Crypto markets
+    # (and individual trade prints) express fractional volumes routinely (e.g.,
+    # 0.12345 BTC). A prior `.to_i` coercion in #initialize silently truncated and
+    # passed loose `eq(2.0)` assertions because Ruby's `==` coerces `2 == 2.0`.
+    # This block asserts both the value AND the class so future regressions fail loudly.
+    # See OHLC for the parallel fix.
+    context "with fractional crypto-style volumes" do
+      let(:hash) do
+        { "ct" => close_time.to_i, "cp" => 1.0,
+          "bv" => 0.12345, "tv" => 5_678.901_234 }
+      end
+
+      it { expect(subject.base_volume).to eq(0.12345) }
+      it { expect(subject.target_volume).to eq(5_678.901_234) }
+      it { expect(subject.base_volume).to be_a(Float) }
+      it { expect(subject.target_volume).to be_a(Float) }
+    end
   end
 
   describe ".from_json" do


### PR DESCRIPTION
## Summary

- **Bug fix:** base_volume and target_volume were coerced with .to_i in both Quant::Ticks::OHLC and Quant::Ticks::Spot, silently truncating fractional values. Changed to .to_f — crypto and many futures markets routinely express fractional volumes (e.g. 0.12345 BTC).
- **Regression specs:** Added test blocks that assert both the value and the class (be_a(Float)) for fractional crypto-style volumes so future regressions fail loudly rather than being masked by Ruby's == coercion between Integer and Float.
- **Gemspec:** Fixed changelog_uri to point directly to CHANGELOG.md in the repo.
- **Gitignore:** Added .serena/ to .gitignore.

## Test plan

- [x] bundle exec rspec spec/lib/quant/ticks/ohlc_spec.rb passes, including new fractional-volume context
- [x] bundle exec rspec spec/lib/quant/ticks/spot_spec.rb passes, including new fractional-volume context
- [x] bundle exec rspec full suite passes

Generated with [Claude Code](https://claude.com/claude-code)